### PR TITLE
Improve event boxes

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -235,7 +235,7 @@ section.events{
     div.panel {
         @include box-shadow(1px 5px 8px 1px rgba(0,0,0,.19));
         @include border-radius(0);
-        height: 170px;
+        height: 250px;
         position: relative;
         top: 0;
         @include transition(all .1s linear);
@@ -271,7 +271,7 @@ section.events{
 
         .panel-heading {
             padding: 0;
-            height: 70px;
+            height: 150px;
             background-color: darken($accent-color,5%);
             @include border-radius(0);
 
@@ -279,7 +279,7 @@ section.events{
             img {
                 position: relative; 
                 object-fit: cover;
-                height: 70px;
+                height: 150px;
                 width: 100%;
                 filter: brightness(60%) grayscale(20%);
                 &.light_background {
@@ -288,13 +288,13 @@ section.events{
             }
 
             h1,h2,h3, h4{
+                text-align: center;
                 position: absolute;
-                top: 0px;
+                top: 26%;
                 z-index: 10;
                 text-transform: uppercase;
-                padding: 10px;
                 color: $accent-text-color;
-
+                width: 100%;
 
                 &.light_background{
                     color: black;

--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ layout: base
                             <div class="panel-heading">
                                 <span class="past-text biko">PAST</span>
                                 {% if event.image-url %}<img class="img-responsive {% unless event.light_background == null %}light_background{% endunless %}" src="{{event.image-url}}">{%endif%}
-                                <h4 class="biko {% unless event.light_background == null %}light_background{% endunless %}" >{{event.name}}</h4>
+                                <h4 class="event-name biko {% unless event.light_background == null %}light_background{% endunless %}" >{{event.name}}</h4>
                             </div>
                             <div class="panel-body event" data-date="{{ event.date }}">                                
                                 <p>{{event.line}}</p>


### PR DESCRIPTION
<img width="1253" alt="screen shot 2018-10-16 at 12 12 34 am" src="https://user-images.githubusercontent.com/3988879/46999002-28746f00-d0d9-11e8-9d47-cc695a30bcce.png">

![image](https://user-images.githubusercontent.com/3988879/46999025-39bd7b80-d0d9-11e8-8188-61dbe8cf241a.png)

<img width="1261" alt="screen shot 2018-10-16 at 12 12 41 am" src="https://user-images.githubusercontent.com/3988879/46999033-3fb35c80-d0d9-11e8-9290-e59a9dfe9fcb.png">




## Description
This PR visually improves the event boxes. I made the boxes larger, which allowed for an increased background photo size. I also centered and repositioned the event titles.

## Some questions
- [x] I read the contributing guidelines


By @elliotwhitehead 